### PR TITLE
feat: Add auditing support using Spring Data JPA Auditing

### DIFF
--- a/section-02/accounts/src/main/java/com/easybytes/accounts/AccountsApplication.java
+++ b/section-02/accounts/src/main/java/com/easybytes/accounts/AccountsApplication.java
@@ -2,8 +2,10 @@ package com.easybytes.accounts;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing(auditorAwareRef = "auditorAware")
 public class AccountsApplication {
 
 	public static void main(String[] args) {

--- a/section-02/accounts/src/main/java/com/easybytes/accounts/audits/AuditorAwareImpl.java
+++ b/section-02/accounts/src/main/java/com/easybytes/accounts/audits/AuditorAwareImpl.java
@@ -1,0 +1,16 @@
+package com.easybytes.accounts.audits;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component("auditorAware")
+public class AuditorAwareImpl implements AuditorAware<String> {
+
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        // In real application, fetch the logged-in username (e.g., from Spring Security)
+        return Optional.of("ACCOUNTS_MS");
+    }
+}

--- a/section-02/accounts/src/main/java/com/easybytes/accounts/entity/BaseEntity.java
+++ b/section-02/accounts/src/main/java/com/easybytes/accounts/entity/BaseEntity.java
@@ -1,10 +1,16 @@
 package com.easybytes.accounts.entity;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -12,15 +18,22 @@ import java.time.LocalDateTime;
 @Setter
 @ToString
 @MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {
 
+    @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt;
+
+    @CreatedBy
     @Column(updatable = false)
     private String createdBy;
+
+    @LastModifiedDate
     @Column(insertable = false)
     private LocalDateTime updatedAt;
 
+    @LastModifiedBy
     @Column(insertable = false)
     private String updatedBy;
 }

--- a/section-02/accounts/src/main/java/com/easybytes/accounts/services/impl/AccountServiceImpl.java
+++ b/section-02/accounts/src/main/java/com/easybytes/accounts/services/impl/AccountServiceImpl.java
@@ -108,8 +108,9 @@ public class AccountServiceImpl implements IAccountService {
         newAccount.setBranchAddress(AccountsConstants.ADDRESS);
 
         // 🛠️ Fix for error
-        newAccount.setCreatedAt(LocalDateTime.now());
-        newAccount.setCreatedBy("system");
+        // below two lines are not required as we are using AuditAwareImpl
+//        newAccount.setCreatedAt(LocalDateTime.now());
+//        newAccount.setCreatedBy("system");
         return newAccount;
     }
 }


### PR DESCRIPTION
- Created BaseEntity with audit fields: createdAt, createdBy, updatedAt, updatedBy
- Enabled JPA auditing via @EnableJpaAuditing
- Implemented AuditorAware to return fixed user 'ACCOUNTS_MS'
- Applied @EntityListeners(AuditingEntityListener.class) to entity classes